### PR TITLE
Remove Helix logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,7 +154,6 @@
             <a href="https://www.erasmushogeschool.be" target="_blank"><img src="images/Logo/Erasmus.png" alt=""/></a>
             <a href="https://www.spectrumcollege.be" target="_blank"><img src="images/Logo/Spectrum.png" alt=""/></a>
             <a href="https://www.forelo.be" target="_blank"><img src="images/Logo/Forelo.png" alt=""/></a>
-            <a href="https://www.helixlearning.nl" target="_blank"><img src="images/Logo/HelixLearning.png" alt=""/></a>
         </div>
     </div>
 


### PR DESCRIPTION
Scalda Next (Helix Learning) asked to remove their logo from this website.